### PR TITLE
Revert "Update env_logger requirement from 0.9.0 to 0.10.0"

### DIFF
--- a/prost-reflect-conformance-tests/Cargo.toml
+++ b/prost-reflect-conformance-tests/Cargo.toml
@@ -21,7 +21,7 @@ doctest = false
 prost = "0.11.0"
 prost-types = "0.11.0"
 prost-reflect = { path = "../prost-reflect", features = ["serde", "text-format"] }
-env_logger = "0.10.0"
+env_logger = "0.9.0"
 serde_json = { version = "1.0.74", features = ["float_roundtrip"] }
 serde = "1.0.133"
 once_cell = "1.9.0"


### PR DESCRIPTION
Reverts andrewhickman/prost-reflect#20

This fails dependency resolution, seemingly only on the old cargo dependency resolver