### PR TITLE
make some of the code behind build_files non-polymorphic

### DIFF
--- a/prost-reflect/src/descriptor/build/names.rs
+++ b/prost-reflect/src/descriptor/build/names.rs
@@ -24,10 +24,10 @@ use crate::{
 };
 
 impl DescriptorPoolInner {
-    pub(super) fn collect_names<'a>(
+    pub(super) fn collect_names(
         &mut self,
         offsets: DescriptorPoolOffsets,
-        files: impl Iterator<Item = &'a FileDescriptorProto>,
+        files: &[FileDescriptorProto],
     ) -> Result<(), DescriptorError> {
         let mut visitor = NameVisitor {
             pool: self,

--- a/prost-reflect/src/descriptor/build/options.rs
+++ b/prost-reflect/src/descriptor/build/options.rs
@@ -28,7 +28,7 @@ use crate::{
 use super::resolve_name;
 
 impl DescriptorPool {
-    pub(super) fn resolve_options<'a>(
+    pub(super) fn resolve_options(
         &mut self,
         offsets: DescriptorPoolOffsets,
         files: &[FileDescriptorProto],

--- a/prost-reflect/src/descriptor/build/options.rs
+++ b/prost-reflect/src/descriptor/build/options.rs
@@ -31,7 +31,7 @@ impl DescriptorPool {
     pub(super) fn resolve_options<'a>(
         &mut self,
         offsets: DescriptorPoolOffsets,
-        files: impl Iterator<Item = &'a FileDescriptorProto>,
+        files: &[FileDescriptorProto],
     ) -> Result<(), DescriptorError> {
         debug_assert_eq!(Arc::strong_count(&self.inner), 1);
         let mut visitor = OptionsVisitor {

--- a/prost-reflect/src/descriptor/build/resolve.rs
+++ b/prost-reflect/src/descriptor/build/resolve.rs
@@ -24,10 +24,10 @@ use crate::{
 };
 
 impl DescriptorPoolInner {
-    pub(super) fn resolve_names<'a>(
+    pub(super) fn resolve_names(
         &mut self,
         offsets: DescriptorPoolOffsets,
-        files: impl Iterator<Item = &'a FileDescriptorProto>,
+        files: &[FileDescriptorProto],
     ) -> Result<(), DescriptorError> {
         let mut visitor = ResolveVisitor {
             pool: self,

--- a/prost-reflect/src/descriptor/build/visit.rs
+++ b/prost-reflect/src/descriptor/build/visit.rs
@@ -100,13 +100,11 @@ pub(super) trait Visitor {
     }
 }
 
-pub(super) fn visit<'a, V>(
+pub(super) fn visit(
     offsets: DescriptorPoolOffsets,
-    files: impl IntoIterator<Item = &'a FileDescriptorProto>,
-    visitor: &mut V,
-) where
-    V: Visitor,
-{
+    files: &[FileDescriptorProto],
+    visitor: &mut impl Visitor,
+) {
     let mut context = Context {
         path: Vec::new(),
         scope: String::new(),


### PR DESCRIPTION
Hi, thanks so much for putting together this crate, it's been super helpful in building dynamic gRPC functionality.

I'm overall very happy with `prost-reflect`, but while working on reducing the size of my binaries using `cargo bloat` I noticed that it was using significant space in the text section, both directly through `decode_file_descriptor_set` and `decode` but also in the methods in my code calling `decode_file_descriptor_set` due to inlining.

Trying to understand why this might be, I came across this optimization. The problem with the `build_files` method is that it takes a generic `IntoIterator`, which means the function is monomorphized at multiple sites in `DescriptorPool`. Because the logic inside `build_files` becomes quite complex with the different visitors, this results in a decent amount of code bloat.

The change I'm proposing here simply moves the bulk of the heavy logic into a non-polymorphic function (`build_files_deduped`) without changing any functionality whatsoever. This should be fully equivalent in terms of performance and behaviour, with the only difference being that the binary footprint of users of the crate should be significantly reduced.

In my particular case, this change reduces the total binary size by ~86KiB, which represents a saving of more than 1/4 of the total code size attributable to `prost-reflect` (335.4KiB according to `cargo bloat` before the optimization).

---

As an aside, I've also noticed that there are two other places where generics cause multiple copies of very large functions and/or sections of code: `Visitor` and `FieldDescriptorLike`. I am wondering whether you have considered switching the functions taking impls of these traits to use `dyn` traits instead? That seems like it has the potential to reduce code size somewhat further, but may need to be benchmarked due to the dynamic dispatch it'd introduce.