### PR TITLE
use dynamic dispatch for visitors

### DIFF
--- a/prost-reflect/src/descriptor/build/visit.rs
+++ b/prost-reflect/src/descriptor/build/visit.rs
@@ -103,7 +103,7 @@ pub(super) trait Visitor {
 pub(super) fn visit(
     offsets: DescriptorPoolOffsets,
     files: &[FileDescriptorProto],
-    visitor: &mut impl Visitor,
+    visitor: &mut dyn Visitor,
 ) {
     let mut context = Context {
         path: Vec::new(),
@@ -123,7 +123,7 @@ struct Context {
 }
 
 impl Context {
-    fn visit_file(&mut self, file: &FileDescriptorProto, visitor: &mut impl Visitor) {
+    fn visit_file(&mut self, file: &FileDescriptorProto, visitor: &mut dyn Visitor) {
         if !file.package().is_empty() {
             self.push_scope(file.package());
         }
@@ -171,7 +171,7 @@ impl Context {
     fn visit_message(
         &mut self,
         message: &DescriptorProto,
-        visitor: &mut impl Visitor,
+        visitor: &mut dyn Visitor,
         file: FileIndex,
         parent_message: Option<MessageIndex>,
     ) {
@@ -233,7 +233,7 @@ impl Context {
     fn visit_field(
         &mut self,
         field: &FieldDescriptorProto,
-        visitor: &mut impl Visitor,
+        visitor: &mut dyn Visitor,
         file: FileIndex,
         message: MessageIndex,
         index: FieldIndex,
@@ -246,7 +246,7 @@ impl Context {
     fn visit_oneof(
         &mut self,
         oneof: &OneofDescriptorProto,
-        visitor: &mut impl Visitor,
+        visitor: &mut dyn Visitor,
         file: FileIndex,
         message: MessageIndex,
         index: OneofIndex,
@@ -259,7 +259,7 @@ impl Context {
     fn visit_service(
         &mut self,
         service: &ServiceDescriptorProto,
-        visitor: &mut impl Visitor,
+        visitor: &mut dyn Visitor,
         file: FileIndex,
     ) {
         self.push_scope(service.name());
@@ -281,7 +281,7 @@ impl Context {
     fn visit_method(
         &mut self,
         method: &MethodDescriptorProto,
-        visitor: &mut impl Visitor,
+        visitor: &mut dyn Visitor,
         file: FileIndex,
         service: ServiceIndex,
         index: MethodIndex,
@@ -294,7 +294,7 @@ impl Context {
     fn visit_enum(
         &mut self,
         enum_: &EnumDescriptorProto,
-        visitor: &mut impl Visitor,
+        visitor: &mut dyn Visitor,
         file: FileIndex,
         parent_message: Option<MessageIndex>,
     ) {
@@ -317,7 +317,7 @@ impl Context {
     fn visit_enum_value(
         &mut self,
         value: &EnumValueDescriptorProto,
-        visitor: &mut impl Visitor,
+        visitor: &mut dyn Visitor,
         file: FileIndex,
         enum_: EnumIndex,
         index: EnumValueIndex,
@@ -330,7 +330,7 @@ impl Context {
     fn visit_extension(
         &mut self,
         extension: &FieldDescriptorProto,
-        visitor: &mut impl Visitor,
+        visitor: &mut dyn Visitor,
         file: FileIndex,
         parent_message: Option<MessageIndex>,
     ) {


### PR DESCRIPTION
Following up from the discussion in #40, this changes the visitor pattern to use dynamic dispatch. In my case, this reduces the text section size attributed to `prost-reflect` by ~6.2% from 311.8KiB to 292.4KiB.

In parallel, I'm also working to create a simple benchmark for testing the impact of changing `FieldDescriptorLike`, which should result in a slightly larger amount of size reduction if things go well.