### PR TITLE
remove source code info from wkt bin

### DIFF
--- a/prost-reflect/Cargo.toml
+++ b/prost-reflect/Cargo.toml
@@ -49,6 +49,10 @@ prost-reflect-build = { path = "../prost-reflect-build" }
 serde_json = "1.0.82"
 serde_yaml = "0.9.16"
 
+[build-dependencies]
+prost = "0.11.0"
+prost-types = "0.11.0"
+
 [package.metadata.release]
 tag-name = "{{version}}"
 sign-tag = true

--- a/prost-reflect/build.rs
+++ b/prost-reflect/build.rs
@@ -1,0 +1,22 @@
+use std::io::Result;
+
+use prost::Message;
+use prost_types::FileDescriptorSet;
+
+fn main() -> Result<()> {
+    println!("cargo:rerun-if-changed=src/well_known_types.bin");
+
+    let mut wkt_bin = std::fs::read("./src/well_known_types.bin")?;
+    let mut wkt_set = FileDescriptorSet::decode(wkt_bin.as_slice())?;
+    for mut file in wkt_set.file.iter_mut() {
+        file.source_code_info = None; // clear source code info
+    }
+
+    wkt_bin.clear();
+    wkt_set.encode(&mut wkt_bin)?;
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let dest_path = std::path::Path::new(&out_dir).join("well_known_types.bin");
+    std::fs::write(dest_path, wkt_bin)?;
+    Ok(())
+}

--- a/prost-reflect/src/reflect/wkt.rs
+++ b/prost-reflect/src/reflect/wkt.rs
@@ -1,6 +1,7 @@
 use crate::{DescriptorPool, MessageDescriptor, ReflectMessage};
 
-pub(crate) const WELL_KNOWN_TYPES_BYTES: &[u8] = include_bytes!("../well_known_types.bin");
+pub(crate) const WELL_KNOWN_TYPES_BYTES: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/well_known_types.bin"));
 
 macro_rules! impl_reflect_message {
     ($($ty:ty => $name:literal;)*) => {


### PR DESCRIPTION
Based on your hint in #41, I went and looked at the `well_known_types.bin` file that's included in the binary, and noticed that the file descriptors all include `source_code_info`. In fact, the `source_code_info` on the files accounts for most of the size of `well_known_types.bin`.

This patch here adds a build script that removes the source code info from the file before including it in the binary. It results in a reduction in binary size of ~99KB, which based on the size of the WKT file means that we're reducing its size from ~115KB down to ~16KB.

We could consider just modifying the file directly in source control rather than using a build script, but I'm not sure how the file was sourced or how it will be updated in the future. The build script seems to add very little overhead to the compilation process.

As far as I can see, the missing source code info shouldn't impact any of the functionality that depends on the WKT descriptors, but let me know if you have any concerns with this approach!