### PR TITLE
Add support for unknown fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added new `DynamicMessage` APIs for getting and clearing message fields:
-  - [`fields`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.fields) Gets an iterator over all fields of this message.
-  - [`extensions`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.extensions) Gets an iterator over all extension fields of this message.
-  - [`take_field`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_field) Clears the value for the given field, and returns it.
-  - [`take_field_by_name`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_field_by_name) Clears the value for the field with the given name, and returns it.
-  - [`take_field_by_number`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_field_by_number) Clears the value for the field with the given number, and returns it.
-  - [`take_extension`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_extension) Clears the value for the given extension field and returns it.
+- Added new APIs for getting and clearing message fields:
+  - [`DynamicMessage::fields`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.fields) Gets an iterator over all fields of this message.
+  - [`DynamicMessage::fields_mut`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.fields_mut) Gets an iterator returning mutable references to all fields of this message.
+  - [`DynamicMessage::take_fields`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_fields) Clears all fields from the message and returns an iterator yielding the values.
+  - [`DynamicMessage::extensions`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.extensions) Gets an iterator over all extension fields of this message.
+  - [`DynamicMessage::extensions_mut`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.extensions_mut) Gets an iterator returning mutable references to all extension fields of this message.
+  - [`DynamicMessage::take_extensions`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_extensions) Clears all extension fields from the message and returns an iterator yielding the values.
+  - [`DynamicMessage::take_field`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_field) Clears the value for the given field, and returns it.
+  - [`DynamicMessage::take_field_by_name`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_field_by_name) Clears the value for the field with the given name, and returns it.
+  - [`DynamicMessage::take_field_by_number`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_field_by_number) Clears the value for the field with the given number, and returns it.
+  - [`DynamicMessage::take_extension`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_extension) Clears the value for the given extension field and returns it.
 - Added new APIs for inspecting unknown fields of a message.
   - [`DynamicMessage::unknown_fields()`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.unknown_fields) Gets an iterator over unknown fields for this message.
+  - [`DynamicMessage::take_unknown_fields()`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_unknown_fields) Clears all unknown fields from the message and returns an iterator yielding the values.
   - [`UnknownField`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.UnknownField.html) An unknown field found when deserializing a protobuf message..
 
 ## [0.11.4] - 2023-04-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [`take_field_by_name`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_field_by_name) Clears the value for the field with the given name, and returns it.
   - [`take_field_by_number`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_field_by_number) Clears the value for the field with the given number, and returns it.
   - [`take_extension`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.take_extension) Clears the value for the given extension field and returns it.
+- Added new APIs for inspecting unknown fields of a message.
+  - [`DynamicMessage::unknown_fields()`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.DynamicMessage.html#method.unknown_fields) Gets an iterator over unknown fields for this message.
+  - [`UnknownField`](https://docs.rs/prost-reflect/latest/prost_reflect/struct.UnknownField.html) An unknown field found when deserializing a protobuf message..
 
 ## [0.11.4] - 2023-04-28
 

--- a/prost-reflect-tests/src/decode.rs
+++ b/prost-reflect-tests/src/decode.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use proptest::{prelude::*, test_runner::TestCaseError};
-use prost::{bytes::Bytes, Message};
+use prost::{bytes::Bytes, encoding::WireType, Message};
 use prost_reflect::{DynamicMessage, MapKey, ReflectMessage, Value};
 use prost_types::FileDescriptorSet;
 
@@ -766,6 +766,15 @@ fn unknown_fields_are_roundtripped() {
     message.merge(BYTES).unwrap();
 
     assert_eq!(&message.encode_to_vec(), BYTES);
+
+    let unknown_fields = message.unknown_fields().cloned().collect::<Vec<_>>();
+    assert_eq!(unknown_fields.len(), 1);
+    assert_eq!(unknown_fields[0].number(), 1);
+    assert_eq!(unknown_fields[0].wire_type(), WireType::Varint);
+    assert_eq!(unknown_fields[0].encoded_len(), 3);
+    let mut field_buf = Vec::new();
+    unknown_fields[0].encode(&mut field_buf);
+    assert_eq!(field_buf, BYTES);
 }
 
 #[test]

--- a/prost-reflect-tests/src/decode.rs
+++ b/prost-reflect-tests/src/decode.rs
@@ -775,6 +775,10 @@ fn unknown_fields_are_roundtripped() {
     let mut field_buf = Vec::new();
     unknown_fields[0].encode(&mut field_buf);
     assert_eq!(field_buf, BYTES);
+
+    assert!(message.take_unknown_fields().eq(unknown_fields));
+    assert!(message.encode_to_vec().is_empty());
+    assert_eq!(message.unknown_fields().count(), 0);
 }
 
 #[test]

--- a/prost-reflect-tests/src/desc.rs
+++ b/prost-reflect-tests/src/desc.rs
@@ -686,10 +686,10 @@ fn message_list_extensions() {
             .get_field_by_name("int")
             .unwrap(),
         &Value::I32(0)
-    ),]));
+    )]));
     assert!(dynamic_message
         .extensions()
-        .eq([(extension_desc, &Value::F64(42.0)),]));
+        .eq([(extension_desc, &Value::F64(42.0))]));
 }
 
 #[test]
@@ -746,4 +746,29 @@ fn message_take_field() {
     assert_eq!(message.take_field_by_name("optional_enum"), Some(num));
 
     assert!(message.fields().eq([]));
+}
+
+#[test]
+fn message_take_fields() {
+    let message_desc = test_file_descriptor()
+        .get_message_by_name("my.package2.MyMessage")
+        .unwrap();
+
+    let extension_desc = message_desc.get_extension(113).unwrap();
+
+    let mut dynamic_message = DynamicMessage::new(message_desc.clone());
+
+    assert_eq!(dynamic_message.fields().count(), 0);
+    assert_eq!(dynamic_message.extensions().count(), 0);
+
+    dynamic_message.set_field_by_name("int", Value::I32(0));
+    dynamic_message.set_extension(&extension_desc, Value::F64(42.0));
+
+    assert!(dynamic_message.take_fields().eq([(
+        message_desc.get_field_by_name("int").unwrap(),
+        Value::I32(0)
+    )]));
+    assert!(dynamic_message
+        .take_extensions()
+        .eq([(extension_desc, Value::F64(42.0))]));
 }

--- a/prost-reflect-tests/src/desc.rs
+++ b/prost-reflect-tests/src/desc.rs
@@ -670,26 +670,32 @@ fn message_list_extensions() {
         .get_message_by_name("my.package2.MyMessage")
         .unwrap();
 
+    let field_desc = message_desc.get_field_by_name("int").unwrap();
     let extension_desc = message_desc.get_extension(113).unwrap();
 
     let mut dynamic_message = DynamicMessage::new(message_desc.clone());
 
     assert_eq!(dynamic_message.fields().count(), 0);
     assert_eq!(dynamic_message.extensions().count(), 0);
+    assert_eq!(dynamic_message.fields_mut().count(), 0);
+    assert_eq!(dynamic_message.extensions_mut().count(), 0);
 
-    dynamic_message.set_field_by_name("int", Value::I32(0));
+    dynamic_message.set_field(&field_desc, Value::I32(0));
     dynamic_message.set_extension(&extension_desc, Value::F64(42.0));
 
-    assert!(dynamic_message.fields().eq([(
-        dynamic_message
-            .descriptor()
-            .get_field_by_name("int")
-            .unwrap(),
-        &Value::I32(0)
-    )]));
+    assert!(dynamic_message
+        .fields()
+        .eq([(field_desc.clone(), &Value::I32(0))]));
     assert!(dynamic_message
         .extensions()
-        .eq([(extension_desc, &Value::F64(42.0))]));
+        .eq([(extension_desc.clone(), &Value::F64(42.0))]));
+
+    assert!(dynamic_message
+        .fields_mut()
+        .eq([(field_desc, &mut Value::I32(0))]));
+    assert!(dynamic_message
+        .extensions_mut()
+        .eq([(extension_desc, &mut Value::F64(42.0))]));
 }
 
 #[test]
@@ -754,21 +760,28 @@ fn message_take_fields() {
         .get_message_by_name("my.package2.MyMessage")
         .unwrap();
 
+    let field_desc = message_desc.get_field_by_name("int").unwrap();
     let extension_desc = message_desc.get_extension(113).unwrap();
 
     let mut dynamic_message = DynamicMessage::new(message_desc.clone());
 
     assert_eq!(dynamic_message.fields().count(), 0);
     assert_eq!(dynamic_message.extensions().count(), 0);
+    assert_eq!(dynamic_message.fields_mut().count(), 0);
+    assert_eq!(dynamic_message.extensions_mut().count(), 0);
 
-    dynamic_message.set_field_by_name("int", Value::I32(0));
+    dynamic_message.set_field(&field_desc, Value::I32(0));
     dynamic_message.set_extension(&extension_desc, Value::F64(42.0));
 
-    assert!(dynamic_message.take_fields().eq([(
-        message_desc.get_field_by_name("int").unwrap(),
-        Value::I32(0)
-    )]));
+    assert!(dynamic_message
+        .take_fields()
+        .eq([(field_desc, Value::I32(0))]));
     assert!(dynamic_message
         .take_extensions()
         .eq([(extension_desc, Value::F64(42.0))]));
+
+    assert_eq!(dynamic_message.fields().count(), 0);
+    assert_eq!(dynamic_message.extensions().count(), 0);
+    assert_eq!(dynamic_message.fields_mut().count(), 0);
+    assert_eq!(dynamic_message.extensions_mut().count(), 0);
 }

--- a/prost-reflect/src/descriptor/global.rs
+++ b/prost-reflect/src/descriptor/global.rs
@@ -15,13 +15,13 @@ impl DescriptorPool {
     /// The global descriptor pool is typically used as a convenient place to store descriptors for `ReflectMessage` implementations.
     ///
     /// Note that modifications to the returned pool won't affect the global pool - use
-    /// [`decode_global_file_descriptor_set`](decode_global_file_descriptor_set) or
-    /// [`add_global_file_descriptor`](add_global_file_descriptor) to modify the global pool.
+    /// [`decode_global_file_descriptor_set`](DescriptorPool::decode_global_file_descriptor_set) or
+    /// [`add_global_file_descriptor_proto`](DescriptorPool::add_global_file_descriptor_proto) to modify the global pool.
     pub fn global() -> DescriptorPool {
         INSTANCE.lock().unwrap().clone()
     }
 
-    /// Decodes and adds a set of file descriptors to the pool.
+    /// Decodes and adds a set of file descriptors to the global pool.
     ///
     /// See [`DescriptorPool::decode_file_descriptor_set`] for more details.
     pub fn decode_global_file_descriptor_set<B>(bytes: B) -> Result<(), DescriptorError>

--- a/prost-reflect/src/dynamic/message.rs
+++ b/prost-reflect/src/dynamic/message.rs
@@ -28,11 +28,7 @@ impl Message for DynamicMessage {
                 ValueAndDescriptor::Extension(value, extension_desc) => {
                     value.encode_field(&extension_desc, buf)
                 }
-                ValueAndDescriptor::Unknown(number, unknowns) => {
-                    for unknown in unknowns {
-                        unknown.encode_field(number, buf);
-                    }
-                }
+                ValueAndDescriptor::Unknown(_, unknowns) => unknowns.encode_raw(buf),
             }
         }
     }
@@ -59,7 +55,7 @@ impl Message for DynamicMessage {
                 ctx,
             )
         } else {
-            let field = UnknownField::decode(number, wire_type, buf, ctx)?;
+            let field = UnknownField::decode_value(number, wire_type, buf, ctx)?;
             self.fields.add_unknown(number, field);
             Ok(())
         }
@@ -75,11 +71,7 @@ impl Message for DynamicMessage {
                 ValueAndDescriptor::Extension(value, extension_desc) => {
                     len += value.encoded_len(&extension_desc);
                 }
-                ValueAndDescriptor::Unknown(number, unknowns) => {
-                    for unknown in unknowns {
-                        len += unknown.encoded_len(number)
-                    }
-                }
+                ValueAndDescriptor::Unknown(_, unknowns) => len += unknowns.encoded_len(),
             }
         }
         len

--- a/prost-reflect/src/dynamic/mod.rs
+++ b/prost-reflect/src/dynamic/mod.rs
@@ -499,11 +499,43 @@ impl DynamicMessage {
         self.fields.iter_fields(&self.desc)
     }
 
+    /// Gets an iterator returning mutable references to all fields of this message.
+    ///
+    /// The iterator will yield all fields for which [`has_field`](Self::has_field) returns `true`.
+    pub fn fields_mut(&mut self) -> impl Iterator<Item = (FieldDescriptor, &'_ mut Value)> {
+        self.fields.iter_fields_mut(&self.desc)
+    }
+
+    /// Clears all fields from the message and returns an iterator yielding the values.
+    ///
+    /// The iterator will yield all fields for which [`has_field`](Self::has_field) returns `true`.
+    ///
+    /// If the iterator is dropped before completing the iteration, it is unspecified how many fields are removed.
+    pub fn take_fields(&mut self) -> impl Iterator<Item = (FieldDescriptor, Value)> + '_ {
+        self.fields.take_fields(&self.desc)
+    }
+
     /// Gets an iterator over all extension fields of this message.
     ///
     /// The iterator will yield all extension fields for which [`has_extension`](Self::has_extension) returns `true`.
     pub fn extensions(&self) -> impl Iterator<Item = (ExtensionDescriptor, &'_ Value)> {
         self.fields.iter_extensions(&self.desc)
+    }
+
+    /// Gets an iterator returning mutable references to all extension fields of this message.
+    ///
+    /// The iterator will yield all extension fields for which [`has_extension`](Self::has_extension) returns `true`.
+    pub fn extensions_mut(&mut self) -> impl Iterator<Item = (ExtensionDescriptor, &'_ mut Value)> {
+        self.fields.iter_extensions_mut(&self.desc)
+    }
+
+    /// Clears all extension fields from the message and returns an iterator yielding the values.
+    ///
+    /// The iterator will yield all extension fields for which [`has_extension`](Self::has_extension) returns `true`.
+    ///
+    /// If the iterator is dropped before completing the iteration, it is unspecified how many fields are removed.
+    pub fn take_extensions(&mut self) -> impl Iterator<Item = (ExtensionDescriptor, Value)> + '_ {
+        self.fields.take_extensions(&self.desc)
     }
 
     /// Gets an iterator over unknown fields for this message.
@@ -514,6 +546,13 @@ impl DynamicMessage {
     /// Unknown fields are preserved when decoding and re-encoding a message.
     pub fn unknown_fields(&self) -> impl Iterator<Item = &'_ UnknownField> {
         self.fields.iter_unknown()
+    }
+
+    /// Clears all unknown fields from the message and returns an iterator yielding the values.
+    ///
+    /// If the iterator is dropped before completing the iteration, it is unspecified how many fields are removed.
+    pub fn take_unknown_fields(&mut self) -> impl Iterator<Item = UnknownField> + '_ {
+        self.fields.take_unknown()
     }
 
     /// Merge a strongly-typed message into this one.

--- a/prost-reflect/src/dynamic/text_format/format.rs
+++ b/prost-reflect/src/dynamic/text_format/format.rs
@@ -174,7 +174,7 @@ where
         self.fmt_value(value, kind)
     }
 
-    fn fmt_unknown_field(&mut self, field: &UnknownField) -> fmt::Result {
+    pub fn fmt_unknown_field(&mut self, field: &UnknownField) -> fmt::Result {
         write!(self.f, "{}", field.number())?;
         match field.value() {
             UnknownFieldValue::Varint(int) => {

--- a/prost-reflect/src/dynamic/unknown.rs
+++ b/prost-reflect/src/dynamic/unknown.rs
@@ -1,4 +1,4 @@
-use std::{fmt, slice};
+use std::{fmt, slice, vec};
 
 use prost::{
     bytes::{Buf, BufMut, Bytes},
@@ -6,7 +6,7 @@ use prost::{
     DecodeError, Message,
 };
 
-use crate::text_format;
+use crate::dynamic::text_format;
 
 /// An unknown field found when deserializing a protobuf message.
 ///
@@ -226,6 +226,10 @@ impl UnknownFieldSet {
 
     pub(crate) fn iter(&self) -> slice::Iter<'_, UnknownField> {
         self.fields.iter()
+    }
+
+    pub(crate) fn into_iter(self) -> vec::IntoIter<UnknownField> {
+        self.fields.into_iter()
     }
 
     pub(crate) fn insert(&mut self, unknown: UnknownField) {

--- a/prost-reflect/src/dynamic/unknown.rs
+++ b/prost-reflect/src/dynamic/unknown.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::slice;
 
 use prost::{
     bytes::{Buf, BufMut, Bytes},
@@ -6,9 +6,22 @@ use prost::{
     DecodeError, Message,
 };
 
-/// An unknown field in a protobuf message.
+/// An unknown field found when deserializing a protobuf message.
+///
+/// A field is unknown if the message descriptor does not contain a field with the given number. This is often the
+/// result of a new field being added to the message definition.
+///
+/// The [`Message`](prost::Message) implementation of [`DynamicMessage`](crate::DynamicMessage) will preserve any unknown
+/// fields.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) enum UnknownField {
+pub struct UnknownField {
+    number: u32,
+    value: UnknownFieldValue,
+}
+
+/// The vaalue of an unknown field in a protobuf message.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum UnknownFieldValue {
     /// An unknown field with the `Varint` wire type.
     Varint(u64),
     /// An unknown field with the `SixtyFourBit` wire type.
@@ -23,7 +36,134 @@ pub(crate) enum UnknownField {
 
 #[derive(Debug, Default, Clone, PartialEq)]
 pub(crate) struct UnknownFieldSet {
-    fields: BTreeMap<u32, Vec<UnknownField>>,
+    fields: Vec<UnknownField>,
+}
+
+impl UnknownField {
+    /// The number of this field as found during decoding.
+    pub fn number(&self) -> u32 {
+        self.number
+    }
+
+    /// The wire type of this field as found during decoding.
+    pub fn wire_type(&self) -> WireType {
+        match &self.value {
+            UnknownFieldValue::Varint(_) => WireType::Varint,
+            UnknownFieldValue::SixtyFourBit(_) => WireType::SixtyFourBit,
+            UnknownFieldValue::LengthDelimited(_) => WireType::LengthDelimited,
+            UnknownFieldValue::Group(_) => WireType::StartGroup,
+            UnknownFieldValue::ThirtyTwoBit(_) => WireType::ThirtyTwoBit,
+        }
+    }
+
+    pub(crate) fn value(&self) -> &UnknownFieldValue {
+        &self.value
+    }
+
+    /// Encodes this field into its byte representation.
+    pub fn encode<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        match &self.value {
+            UnknownFieldValue::Varint(value) => {
+                encoding::encode_key(self.number, WireType::Varint, buf);
+                encoding::encode_varint(*value, buf);
+            }
+            UnknownFieldValue::SixtyFourBit(value) => {
+                encoding::encode_key(self.number, WireType::SixtyFourBit, buf);
+                buf.put_slice(value);
+            }
+            UnknownFieldValue::LengthDelimited(value) => {
+                encoding::bytes::encode(self.number, value, buf);
+            }
+            UnknownFieldValue::Group(value) => {
+                encoding::group::encode(self.number, value, buf);
+            }
+            UnknownFieldValue::ThirtyTwoBit(value) => {
+                encoding::encode_key(self.number, WireType::ThirtyTwoBit, buf);
+                buf.put_slice(value);
+            }
+        }
+    }
+
+    /// Decodes an unknown field from the given buffer.
+    ///
+    /// This method will read the field number and wire type from the buffer. Normally, it is useful to know
+    /// the field number before deciding whether to treat a field as unknown. See [`decode_value`](UnknownField::decode_value)
+    /// if you have already read the number.
+    pub fn decode<B>(buf: &mut B, ctx: DecodeContext) -> Result<Self, DecodeError>
+    where
+        B: Buf,
+    {
+        let (number, wire_type) = encoding::decode_key(buf)?;
+        Self::decode_value(number, wire_type, buf, ctx)
+    }
+
+    /// Given a field number and wire type, decodes the value of an unknown field.
+    ///
+    /// This method assumes the field number and wire type have already been read from the buffer.
+    /// See also [`decode`](UnknownField::decode).
+    pub fn decode_value<B>(
+        number: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<Self, DecodeError>
+    where
+        B: Buf,
+    {
+        let value = match wire_type {
+            WireType::Varint => {
+                let value = encoding::decode_varint(buf)?;
+                UnknownFieldValue::Varint(value)
+            }
+            WireType::SixtyFourBit => {
+                let mut value = [0; 8];
+                if buf.remaining() < value.len() {
+                    return Err(DecodeError::new("buffer underflow"));
+                }
+                buf.copy_to_slice(&mut value);
+                UnknownFieldValue::SixtyFourBit(value)
+            }
+            WireType::LengthDelimited => {
+                let mut value = Bytes::default();
+                encoding::bytes::merge(wire_type, &mut value, buf, ctx)?;
+                UnknownFieldValue::LengthDelimited(value)
+            }
+            WireType::StartGroup => {
+                let mut value = UnknownFieldSet::default();
+                encoding::group::merge(number, wire_type, &mut value, buf, ctx)?;
+                UnknownFieldValue::Group(value)
+            }
+            WireType::EndGroup => return Err(DecodeError::new("unexpected end group tag")),
+            WireType::ThirtyTwoBit => {
+                let mut value = [0; 4];
+                if buf.remaining() < value.len() {
+                    return Err(DecodeError::new("buffer underflow"));
+                }
+                buf.copy_to_slice(&mut value);
+                UnknownFieldValue::ThirtyTwoBit(value)
+            }
+        };
+
+        Ok(UnknownField { number, value })
+    }
+
+    /// Gets the length of this field when encoded to its byte representation.
+    pub fn encoded_len(&self) -> usize {
+        match &self.value {
+            UnknownFieldValue::Varint(value) => {
+                encoding::key_len(self.number) + encoding::encoded_len_varint(*value)
+            }
+            UnknownFieldValue::SixtyFourBit(value) => encoding::key_len(self.number) + value.len(),
+            UnknownFieldValue::LengthDelimited(value) => {
+                encoding::bytes::encoded_len(self.number, value)
+            }
+            UnknownFieldValue::Group(value) => encoding::group::encoded_len(self.number, value),
+            UnknownFieldValue::ThirtyTwoBit(value) => encoding::key_len(self.number) + value.len(),
+        }
+    }
 }
 
 impl UnknownFieldSet {
@@ -31,10 +171,12 @@ impl UnknownFieldSet {
         self.fields.is_empty()
     }
 
-    pub(crate) fn fields(&self) -> impl Iterator<Item = (u32, &'_ UnknownField)> {
-        self.fields
-            .iter()
-            .flat_map(|(&number, field)| field.iter().map(move |f| (number, f)))
+    pub(crate) fn iter(&self) -> slice::Iter<'_, UnknownField> {
+        self.fields.iter()
+    }
+
+    pub(crate) fn insert(&mut self, unknown: UnknownField) {
+        self.fields.push(unknown);
     }
 }
 
@@ -44,10 +186,8 @@ impl Message for UnknownFieldSet {
         B: BufMut,
         Self: Sized,
     {
-        for (&number, fields) in &self.fields {
-            for field in fields {
-                field.encode_field(number, buf)
-            }
+        for field in &self.fields {
+            field.encode(buf)
         }
     }
 
@@ -62,17 +202,15 @@ impl Message for UnknownFieldSet {
         B: Buf,
         Self: Sized,
     {
-        let field = UnknownField::decode(number, wire_type, buf, ctx)?;
-        self.fields.entry(number).or_default().push(field);
+        let field = UnknownField::decode_value(number, wire_type, buf, ctx)?;
+        self.fields.push(field);
         Ok(())
     }
 
     fn encoded_len(&self) -> usize {
         let mut len = 0;
-        for (&number, fields) in &self.fields {
-            for field in fields {
-                len += field.encoded_len(number);
-            }
+        for field in &self.fields {
+            len += field.encoded_len();
         }
         len
     }
@@ -82,86 +220,133 @@ impl Message for UnknownFieldSet {
     }
 }
 
-impl UnknownField {
-    pub fn encode_field<B>(&self, number: u32, buf: &mut B)
+impl FromIterator<UnknownField> for UnknownFieldSet {
+    fn from_iter<T>(iter: T) -> Self
     where
-        B: BufMut,
+        T: IntoIterator<Item = UnknownField>,
     {
-        match self {
-            UnknownField::Varint(value) => {
-                encoding::encode_key(number, WireType::Varint, buf);
-                encoding::encode_varint(*value, buf);
-            }
-            UnknownField::SixtyFourBit(value) => {
-                encoding::encode_key(number, WireType::SixtyFourBit, buf);
-                buf.put_slice(value);
-            }
-            UnknownField::LengthDelimited(value) => {
-                encoding::bytes::encode(number, value, buf);
-            }
-            UnknownField::Group(value) => {
-                encoding::group::encode(number, value, buf);
-            }
-            UnknownField::ThirtyTwoBit(value) => {
-                encoding::encode_key(number, WireType::ThirtyTwoBit, buf);
-                buf.put_slice(value);
-            }
+        UnknownFieldSet {
+            fields: Vec::from_iter(iter),
         }
     }
+}
 
-    pub fn decode<B>(
-        number: u32,
-        wire_type: WireType,
-        buf: &mut B,
-        ctx: DecodeContext,
-    ) -> Result<Self, DecodeError>
-    where
-        B: Buf,
-    {
-        match wire_type {
-            WireType::Varint => {
-                let value = encoding::decode_varint(buf)?;
-                Ok(UnknownField::Varint(value))
-            }
-            WireType::SixtyFourBit => {
-                let mut value = [0; 8];
-                if buf.remaining() < value.len() {
-                    return Err(DecodeError::new("buffer underflow"));
-                }
-                buf.copy_to_slice(&mut value);
-                Ok(UnknownField::SixtyFourBit(value))
-            }
-            WireType::LengthDelimited => {
-                let mut value = Bytes::default();
-                encoding::bytes::merge(wire_type, &mut value, buf, ctx)?;
-                Ok(UnknownField::LengthDelimited(value))
-            }
-            WireType::StartGroup => {
-                let mut value = UnknownFieldSet::default();
-                encoding::group::merge(number, wire_type, &mut value, buf, ctx)?;
-                Ok(UnknownField::Group(value))
-            }
-            WireType::EndGroup => Err(DecodeError::new("unexpected end group tag")),
-            WireType::ThirtyTwoBit => {
-                let mut value = [0; 4];
-                if buf.remaining() < value.len() {
-                    return Err(DecodeError::new("buffer underflow"));
-                }
-                buf.copy_to_slice(&mut value);
-                Ok(UnknownField::ThirtyTwoBit(value))
-            }
-        }
+#[cfg(test)]
+mod tests {
+    use prost::{
+        bytes::Bytes,
+        encoding::{DecodeContext, WireType},
+    };
+
+    use super::{UnknownField, UnknownFieldSet, UnknownFieldValue};
+
+    fn assert_roundtrip(expected: &[u8], value: &UnknownField) {
+        assert_eq!(expected.len(), value.encoded_len());
+
+        let mut actual = Vec::with_capacity(expected.len());
+        value.encode(&mut actual);
+        assert_eq!(expected, actual.as_slice());
     }
 
-    pub fn encoded_len(&self, number: u32) -> usize {
-        match self {
-            UnknownField::Varint(value) => {
-                encoding::key_len(number) + encoding::encoded_len_varint(*value)
-            }
-            UnknownField::SixtyFourBit(value) => encoding::key_len(number) + value.len(),
-            UnknownField::LengthDelimited(value) => encoding::bytes::encoded_len(number, value),
-            UnknownField::Group(value) => encoding::group::encoded_len(number, value),
-            UnknownField::ThirtyTwoBit(value) => encoding::key_len(number) + value.len(),
-        }
+    #[test]
+    fn sixty_four_bit() {
+        let bytes = b"\x09\x9a\x99\x99\x99\x99\x99\xf1\x3ftail";
+        let mut buf = bytes.as_ref();
+
+        let value = UnknownField::decode(&mut buf, DecodeContext::default()).unwrap();
+
+        assert_eq!(value.number(), 1);
+        assert_eq!(value.wire_type(), WireType::SixtyFourBit);
+        assert_eq!(
+            value.value(),
+            &UnknownFieldValue::SixtyFourBit(*b"\x9a\x99\x99\x99\x99\x99\xf1\x3f")
+        );
+        assert_eq!(buf, b"tail");
+
+        assert_roundtrip(bytes.strip_suffix(buf).unwrap(), &value);
+    }
+
+    #[test]
+    fn thirty_two_bit() {
+        let bytes = b"\x15\xcd\xcc\x0c\x40tail";
+        let mut buf = bytes.as_ref();
+
+        let value = UnknownField::decode(&mut buf, DecodeContext::default()).unwrap();
+
+        assert_eq!(value.number(), 2);
+        assert_eq!(value.wire_type(), WireType::ThirtyTwoBit);
+        assert_eq!(
+            value.value(),
+            &UnknownFieldValue::ThirtyTwoBit(*b"\xcd\xcc\x0c\x40")
+        );
+        assert_eq!(buf, b"tail");
+
+        assert_roundtrip(bytes.strip_suffix(buf).unwrap(), &value);
+    }
+
+    #[test]
+    fn varint() {
+        let bytes = b"\x18\x03tail";
+        let mut buf = bytes.as_ref();
+
+        let value = UnknownField::decode(&mut buf, DecodeContext::default()).unwrap();
+
+        assert_eq!(value.number(), 3);
+        assert_eq!(value.wire_type(), WireType::Varint);
+        assert_eq!(value.value(), &UnknownFieldValue::Varint(3));
+        assert_eq!(buf, b"tail");
+
+        assert_roundtrip(bytes.strip_suffix(buf).unwrap(), &value);
+    }
+
+    #[test]
+    fn length_delimited() {
+        let bytes = b"\x7a\x07\x69\xa6\xbe\x6d\xb6\xff\x58tail";
+        let mut buf = bytes.as_ref();
+
+        let value = UnknownField::decode(&mut buf, DecodeContext::default()).unwrap();
+
+        assert_eq!(value.number(), 15);
+        assert_eq!(value.wire_type(), WireType::LengthDelimited);
+        assert_eq!(
+            value.value(),
+            &UnknownFieldValue::LengthDelimited(Bytes::from_static(
+                b"\x69\xa6\xbe\x6d\xb6\xff\x58"
+            ))
+        );
+        assert_eq!(buf, b"tail");
+
+        assert_roundtrip(bytes.strip_suffix(buf).unwrap(), &value);
+    }
+
+    #[test]
+    fn group() {
+        let bytes = b"\x1b\x0a\x05\x68\x65\x6c\x6c\x6f\x10\x0a\x10\x0b\x1ctail";
+        let mut buf = bytes.as_ref();
+
+        let value = UnknownField::decode(&mut buf, DecodeContext::default()).unwrap();
+
+        assert_eq!(value.number(), 3);
+        assert_eq!(value.wire_type(), WireType::StartGroup);
+        assert_eq!(
+            value.value(),
+            &UnknownFieldValue::Group(UnknownFieldSet::from_iter([
+                UnknownField {
+                    number: 1,
+                    value: UnknownFieldValue::LengthDelimited(Bytes::from_static(b"hello"))
+                },
+                UnknownField {
+                    number: 2,
+                    value: UnknownFieldValue::Varint(10)
+                },
+                UnknownField {
+                    number: 2,
+                    value: UnknownFieldValue::Varint(11)
+                },
+            ]))
+        );
+        assert_eq!(buf, b"tail");
+
+        assert_roundtrip(bytes.strip_suffix(buf).unwrap(), &value);
     }
 }

--- a/prost-reflect/src/lib.rs
+++ b/prost-reflect/src/lib.rs
@@ -24,7 +24,7 @@ pub use self::descriptor::{
     ExtensionDescriptor, FieldDescriptor, FileDescriptor, Kind, MessageDescriptor,
     MethodDescriptor, OneofDescriptor, ServiceDescriptor, Syntax,
 };
-pub use self::dynamic::{DynamicMessage, MapKey, SetFieldError, Value};
+pub use self::dynamic::{DynamicMessage, MapKey, SetFieldError, UnknownField, Value};
 pub use self::reflect::ReflectMessage;
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
This is a minimal API to start with, which only supports getting the number and wire type of unknown fields, and encoding them into another buffer. We are still free to change the internal representation.

Partially implements #15 