### PR TITLE
check for namespace shadowing

### DIFF
--- a/prost-reflect/src/descriptor/mod.rs
+++ b/prost-reflect/src/descriptor/mod.rs
@@ -154,14 +154,14 @@ struct Identity {
     name_index: usize,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct Definition {
     file: FileIndex,
     path: Box<[i32]>,
     kind: DefinitionKind,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 enum DefinitionKind {
     Package,
     Message(MessageIndex),

--- a/prost-reflect/src/descriptor/tests.rs
+++ b/prost-reflect/src/descriptor/tests.rs
@@ -146,15 +146,8 @@ fn resolve_message_name_conflict_with_field_name() {
         }],
     };
 
-    let descriptor_pool = DescriptorPool::from_file_descriptor_set(file_descriptor_set).unwrap();
-    let message = descriptor_pool
-        .get_message_by_name("my.package.MyMessage")
-        .unwrap();
-    let field = message.get_field_by_name("MyMessage").unwrap();
-    assert_eq!(
-        field.kind().as_message().unwrap().full_name(),
-        "my.package.MyMessage"
-    );
+    let e = DescriptorPool::from_file_descriptor_set(file_descriptor_set).unwrap_err();
+    assert_eq!(e.to_string(), "name 'MyMessage' is shadowed");
 }
 
 #[test]

--- a/prost-reflect/tests/data/enum_field_invalid_default3.yml
+++ b/prost-reflect/tests/data/enum_field_invalid_default3.yml
@@ -12,7 +12,7 @@ file:
   messageType:
   - name: Bar
     field:
-    - name: foo
+    - name: foo_field
       number: 1
       label: LABEL_OPTIONAL
       typeName: foo.Foo

--- a/prost-reflect/tests/data/name_resolution4.yml
+++ b/prost-reflect/tests/data/name_resolution4.yml
@@ -1,0 +1,18 @@
+file:
+- name: dep.proto
+  package: foo.bar
+  messageType:
+  - name: FooBar
+- name: root.proto
+  package: com.foo.bar
+  dependency:
+  - dep.proto
+  messageType:
+  - name: Foo
+    field:
+    - name: foobar
+      number: 1
+      label: LABEL_OPTIONAL
+      typeName: foo.FooBar
+      jsonName: foobar
+  syntax: proto3

--- a/prost-reflect/tests/main.rs
+++ b/prost-reflect/tests/main.rs
@@ -132,6 +132,7 @@ check_err!(invalid_service_type3);
 check_err!(name_resolution1);
 check_err!(name_resolution2);
 check_ok!(name_resolution3);
+check_err!(name_resolution4);
 check_err!(name_collision1);
 check_err!(name_collision2);
 check_err!(name_collision3);

--- a/prost-reflect/tests/snapshots/main__name_resolution4.snap
+++ b/prost-reflect/tests/snapshots/main__name_resolution4.snap
@@ -1,0 +1,11 @@
+---
+source: prost-reflect/tests/main.rs
+assertion_line: 79
+expression: actual
+---
+causes: []
+help: "'foo.FooBar' is is resolved to 'com.foo.FooBar', which is not defined. The innermost scope is searched first in name resolution. Consider using a leading '.'(i.e., '.foo.FooBar') to start from the outermost scope."
+labels: []
+message: "name 'foo.FooBar' is shadowed"
+related: []
+severity: error


### PR DESCRIPTION
protoc enforces that the name space resolution stops when it found a relative name which starts with a package fragment contained by the current package

e.g:
if package is com.foo
The type foo.Bar relative name resolution will never reach root path, it will stop searching at com.foo.Bar

The reasoning for this behavior I think is to avoid to have the resolution working at a certain point of time, and later somebody defines com.foo.Bar, and then your type is suddently pointing to somewhere else.
This is why I called it shadowing.

a test in protox is created in https://github.com/andrewhickman/protox/pull/84

todo:

- [x] test with this package test framework

Fix: https://github.com/andrewhickman/protox/issues/82