### PR TITLE
Add skip_default_fields option to text_format

### DIFF
--- a/prost-reflect/src/dynamic/fields.rs
+++ b/prost-reflect/src/dynamic/fields.rs
@@ -175,7 +175,6 @@ impl DynamicMessageFieldSet {
             })
     }
 
-    #[cfg(feature = "serde")]
     pub(crate) fn iter_include_default<'a>(
         &'a self,
         message: &'a MessageDescriptor,

--- a/prost-reflect/src/dynamic/mod.rs
+++ b/prost-reflect/src/dynamic/mod.rs
@@ -1200,3 +1200,19 @@ fn type_sizes() {
     assert_eq!(std::mem::size_of::<DynamicMessage>(), 40);
     assert_eq!(std::mem::size_of::<Value>(), 56);
 }
+
+pub(crate) enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+
+impl<L: Iterator, R: Iterator<Item = L::Item>> Iterator for Either<L, R> {
+    type Item = L::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Either::Left(left) => left.next(),
+            Either::Right(right) => right.next(),
+        }
+    }
+}

--- a/prost-reflect/src/dynamic/text_format/mod.rs
+++ b/prost-reflect/src/dynamic/text_format/mod.rs
@@ -18,6 +18,7 @@ pub struct FormatOptions {
     pretty: bool,
     skip_unknown_fields: bool,
     expand_any: bool,
+    skip_default_fields: bool,
 }
 
 #[cfg(feature = "text-format")]
@@ -145,6 +146,18 @@ impl FormatOptions {
         self
     }
 
+    /// Whether to skip fields which have their default value.
+    ///
+    /// If `true`, any fields for which [`has_field`][DynamicMessage::has_field] returns `false` will
+    /// not be included. If `false`, they will be included with their default value.
+    ///
+    /// The default value is `true`.
+    #[cfg(feature = "text-format")]
+    pub fn skip_default_fields(mut self, yes: bool) -> Self {
+        self.skip_default_fields = yes;
+        self
+    }
+
     /// Whether to use the expanded form of the `google.protobuf.Any` type.
     ///
     /// If set to `true`, `Any` fields will use an expanded form:
@@ -193,6 +206,7 @@ impl Default for FormatOptions {
             pretty: false,
             skip_unknown_fields: true,
             expand_any: true,
+            skip_default_fields: true,
         }
     }
 }


### PR DESCRIPTION
As the name says, allows for text formatting a message with the default values included.

I've added a very simple 'Either' type to simplify the code, also using it for the serde implementation.