### PR TITLE
Add print_message_fields_in_index_order to text-format

### DIFF
--- a/prost-reflect-tests/src/test.proto
+++ b/prost-reflect-tests/src/test.proto
@@ -107,3 +107,9 @@ enum EnumWithAlias {
 message MessageWithAliasedEnum {
   EnumWithAlias aliased = 1;
 }
+
+message IndexOrder {
+  int32 a = 3;
+  int32 b = 2;
+  int32 c = 1;
+}

--- a/prost-reflect-tests/src/text_format.rs
+++ b/prost-reflect-tests/src/text_format.rs
@@ -10,8 +10,8 @@ use prost_reflect::{text_format::FormatOptions, DynamicMessage, ReflectMessage, 
 
 use crate::{
     proto::{
-        contains_group, ComplexType, ContainsGroup, MessageWithAliasedEnum, Point, ScalarArrays,
-        Scalars, WellKnownTypes,
+        contains_group, ComplexType, ContainsGroup, IndexOrder, MessageWithAliasedEnum, Point,
+        ScalarArrays, Scalars, WellKnownTypes,
     },
     test_file_descriptor,
 };
@@ -350,6 +350,23 @@ fn fmt_group() {
     assert_eq!(
         value.to_text_format_with_options(&FormatOptions::new().pretty(true)),
         "RequiredGroup {\n  a: \"bar\"\n}\nOptionalGroup {\n  c: \"foo\"\n  d: -5\n}\nRepeatedGroup: [{\n  e: \"\"\n}, {\n  e: \"hello\"\n  f: 10\n}]"
+    );
+}
+
+#[test]
+fn fmt_index_order() {
+    let value = IndexOrder { a: 1, b: 2, c: 3 }.transcode_to_dynamic();
+    assert_eq!(
+        value.to_text_format_with_options(
+            &FormatOptions::new().print_message_fields_in_index_order(true)
+        ),
+        "a:1,b:2,c:3"
+    );
+    assert_eq!(
+        value.to_text_format_with_options(
+            &FormatOptions::new().print_message_fields_in_index_order(false)
+        ),
+        "c:3,b:2,a:1"
     );
 }
 

--- a/prost-reflect/src/descriptor/api.rs
+++ b/prost-reflect/src/descriptor/api.rs
@@ -756,6 +756,19 @@ impl MessageDescriptor {
             })
     }
 
+    pub(crate) fn fields_in_index_order(
+        &self,
+    ) -> impl ExactSizeIterator<Item = FieldDescriptor> + '_ {
+        self.inner()
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(index, _)| FieldDescriptor {
+                message: self.clone(),
+                index: index as u32,
+            })
+    }
+
     /// Gets an iterator yielding a [`OneofDescriptor`] for each oneof field defined in this message.
     pub fn oneofs(&self) -> impl ExactSizeIterator<Item = OneofDescriptor> + '_ {
         indices(&self.inner().oneofs).map(|index| OneofDescriptor {

--- a/prost-reflect/src/dynamic/message.rs
+++ b/prost-reflect/src/dynamic/message.rs
@@ -19,7 +19,7 @@ impl Message for DynamicMessage {
     where
         Self: Sized,
     {
-        for field in self.fields.iter(&self.desc) {
+        for field in self.fields.iter(&self.desc, false, false) {
             match field {
                 ValueAndDescriptor::Field(value, field_desc) => {
                     value.encode_field(&field_desc, buf)
@@ -61,7 +61,7 @@ impl Message for DynamicMessage {
 
     fn encoded_len(&self) -> usize {
         let mut len = 0;
-        for field in self.fields.iter(&self.desc) {
+        for field in self.fields.iter(&self.desc, false, false) {
             match field {
                 ValueAndDescriptor::Field(value, field_desc) => {
                     len += value.encoded_len(&field_desc);

--- a/prost-reflect/src/dynamic/serde/ser/mod.rs
+++ b/prost-reflect/src/dynamic/serde/ser/mod.rs
@@ -54,11 +54,9 @@ fn serialize_dynamic_message_fields<S>(
 where
     S: SerializeMap,
 {
-    let fields = if options.skip_default_fields {
-        crate::dynamic::Either::Left(value.fields.iter(&value.desc))
-    } else {
-        crate::dynamic::Either::Right(value.fields.iter_include_default(&value.desc))
-    };
+    let fields = value
+        .fields
+        .iter(&value.desc, !options.skip_default_fields, false);
 
     for field in fields {
         let (name, value, ref kind) = match field {

--- a/prost-reflect/src/dynamic/text_format/format.rs
+++ b/prost-reflect/src/dynamic/text_format/format.rs
@@ -42,11 +42,11 @@ where
             }
         }
 
-        let fields = if self.options.skip_default_fields {
-            crate::dynamic::Either::Left(message.fields.iter(&message.desc))
-        } else {
-            crate::dynamic::Either::Right(message.fields.iter_include_default(&message.desc))
-        };
+        let fields = message.fields.iter(
+            &message.desc,
+            !self.options.skip_default_fields,
+            self.options.print_message_fields_in_index_order,
+        );
 
         if self.options.skip_unknown_fields {
             self.fmt_delimited(
@@ -90,13 +90,11 @@ where
                 write!(self.f, "{}", value)
             }
             Value::Message(message) => {
-                let mut fields = if self.options.skip_default_fields {
-                    crate::dynamic::Either::Left(message.fields.iter(&message.desc))
-                } else {
-                    crate::dynamic::Either::Right(
-                        message.fields.iter_include_default(&message.desc),
-                    )
-                };
+                let mut fields = message.fields.iter(
+                    &message.desc,
+                    !self.options.skip_default_fields,
+                    self.options.print_message_fields_in_index_order,
+                );
 
                 if fields.all(|f| {
                     self.options.skip_unknown_fields && matches!(f, ValueAndDescriptor::Unknown(..))

--- a/prost-reflect/src/dynamic/text_format/mod.rs
+++ b/prost-reflect/src/dynamic/text_format/mod.rs
@@ -19,6 +19,7 @@ pub struct FormatOptions {
     skip_unknown_fields: bool,
     expand_any: bool,
     skip_default_fields: bool,
+    print_message_fields_in_index_order: bool,
 }
 
 #[cfg(feature = "text-format")]
@@ -158,6 +159,18 @@ impl FormatOptions {
         self
     }
 
+    /// Whether to print message fields in the order they were defined in source code.
+    ///
+    /// If set to `true`, message fields will be printed in the order they were defined in the source code.
+    /// Otherwise, they will be printed in field number order.
+    ///
+    /// The default value is `false`.
+    #[cfg(feature = "text-format")]
+    pub fn print_message_fields_in_index_order(mut self, yes: bool) -> Self {
+        self.print_message_fields_in_index_order = yes;
+        self
+    }
+
     /// Whether to use the expanded form of the `google.protobuf.Any` type.
     ///
     /// If set to `true`, `Any` fields will use an expanded form:
@@ -207,6 +220,7 @@ impl Default for FormatOptions {
             skip_unknown_fields: true,
             expand_any: true,
             skip_default_fields: true,
+            print_message_fields_in_index_order: false,
         }
     }
 }


### PR DESCRIPTION
Also simplify the iter() method to take arguments instead of a separate instance that includes defaults

Fixes https://github.com/andrewhickman/prost-reflect/issues/133