### PR TITLE
Ignore type name domain when deserializing `Any`

### DIFF
--- a/prost-reflect-tests/src/json.rs
+++ b/prost-reflect-tests/src/json.rs
@@ -999,6 +999,30 @@ fn deserialize_any_allow_unknown_fields() {
 }
 
 #[test]
+fn deserialize_any_custom_type_url() {
+    let value: prost_types::Any = from_json(
+        json!({
+            "@type": "/test.Point",
+            "longitude": 1,
+            "latitude": 2,
+        }),
+        "google.protobuf.Any",
+    );
+
+    assert_eq!(
+        value,
+        prost_types::Any {
+            type_url: "/test.Point".to_owned(),
+            value: Point {
+                longitude: 1,
+                latitude: 2,
+            }
+            .encode_to_vec(),
+        }
+    );
+}
+
+#[test]
 fn deserialize_duration_fraction_digits() {
     let value: prost_types::Duration = from_json(json!("1.00034s"), "google.protobuf.Duration");
 

--- a/prost-reflect/src/dynamic/serde/de/wkt.rs
+++ b/prost-reflect/src/dynamic/serde/de/wkt.rs
@@ -11,7 +11,6 @@ use serde::de::{
 };
 
 use crate::{
-    descriptor::{GOOGLE_APIS_DOMAIN, GOOGLE_PROD_DOMAIN},
     dynamic::{
         serde::{
             case::camel_case_to_snake_case, check_duration, check_timestamp, is_well_known_type,
@@ -462,14 +461,11 @@ fn validate_strict_rfc3339(v: &str) -> Result<(), String> {
 }
 
 fn get_message_name(type_url: &str) -> Result<&str, String> {
-    if let Some(message_name) = type_url
-        .strip_prefix(GOOGLE_APIS_DOMAIN)
-        .or_else(|| type_url.strip_prefix(GOOGLE_PROD_DOMAIN))
-    {
-        Ok(message_name)
-    } else {
-        Err(format!("unsupported type url '{}'", type_url))
-    }
+    let (_type_domain_name, message_name) = type_url
+        .rsplit_once('/')
+        .ok_or_else(|| format!("unsupported type url '{type_url}': missing at least one '/'",))?;
+
+    Ok(message_name)
 }
 
 #[cfg(test)]

--- a/prost-reflect/src/dynamic/serde/de/wkt.rs
+++ b/prost-reflect/src/dynamic/serde/de/wkt.rs
@@ -472,42 +472,67 @@ fn get_message_name(type_url: &str) -> Result<&str, String> {
     }
 }
 
-#[test]
-fn test_validate_strict_rfc3339() {
-    macro_rules! case {
-        ($s:expr => Ok) => {
-            assert_eq!(validate_strict_rfc3339($s), Ok(()))
-        };
-        ($s:expr => Err($e:expr)) => {
-            assert_eq!(validate_strict_rfc3339($s).unwrap_err().to_string(), $e)
-        };
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_strict_rfc3339() {
+        macro_rules! case {
+            ($s:expr => Ok) => {
+                assert_eq!(validate_strict_rfc3339($s), Ok(()))
+            };
+            ($s:expr => Err($e:expr)) => {
+                assert_eq!(validate_strict_rfc3339($s).unwrap_err().to_string(), $e)
+            };
+        }
+
+        case!("1972-06-30T23:59:60Z" => Ok);
+        case!("2019-03-26T14:00:00.9Z" => Ok);
+        case!("2019-03-26T14:00:00.4999Z" => Ok);
+        case!("2019-03-26T14:00:00.4999+10:00" => Ok);
+        case!("2019-03-26t14:00Z" => Err("invalid rfc3339 timestamp: expected 'T' but found 't'"));
+        case!("2019-03-26T14:00z" => Err("invalid rfc3339 timestamp: invalid time"));
+        case!("2019-03-26T14:00:00,999Z" => Err("invalid rfc3339 timestamp: expected 'Z', '+' or '-' but found ','"));
+        case!("2019-03-26T10:00-04" => Err("invalid rfc3339 timestamp: invalid time"));
+        case!("2019-03-26T14:00.9Z" => Err("invalid rfc3339 timestamp: invalid time"));
+        case!("20190326T1400Z" => Err("invalid rfc3339 timestamp: invalid date"));
+        case!("2019-02-30" => Err("invalid rfc3339 timestamp: expected 'T' but found end of string"));
+        case!("2019-03-25T24:01Z" => Err("invalid rfc3339 timestamp: invalid time"));
+        case!("2019-03-26T14:00+24:00" => Err("invalid rfc3339 timestamp: invalid time"));
+        case!("2019-03-26Z" => Err("invalid rfc3339 timestamp: expected 'T' but found 'Z'"));
+        case!("2019-03-26+01:00" => Err("invalid rfc3339 timestamp: expected 'T' but found '+'"));
+        case!("2019-03-26-04:00" => Err("invalid rfc3339 timestamp: expected 'T' but found '-'"));
+        case!("2019-03-26T10:00-0400" => Err("invalid rfc3339 timestamp: invalid time"));
+        case!("+0002019-03-26T14:00Z" => Err("invalid rfc3339 timestamp: invalid date"));
+        case!("+2019-03-26T14:00Z" => Err("invalid rfc3339 timestamp: invalid date"));
+        case!("002019-03-26T14:00Z" => Err("invalid rfc3339 timestamp: invalid date"));
+        case!("019-03-26T14:00Z" => Err("invalid rfc3339 timestamp: invalid date"));
+        case!("2019-03-26T10:00Q" => Err("invalid rfc3339 timestamp: invalid time"));
+        case!("2019-03-26T10:00T" => Err("invalid rfc3339 timestamp: invalid time"));
+        case!("2019-03-26Q" => Err("invalid rfc3339 timestamp: expected 'T' but found 'Q'"));
+        case!("2019-03-26T" => Err("invalid rfc3339 timestamp: invalid time"));
+        case!("2019-03-26 14:00Z" => Err("invalid rfc3339 timestamp: expected 'T' but found ' '"));
+        case!("2019-03-26T14:00:00." => Err("invalid rfc3339 timestamp: empty fractional seconds"));
     }
 
-    case!("1972-06-30T23:59:60Z" => Ok);
-    case!("2019-03-26T14:00:00.9Z" => Ok);
-    case!("2019-03-26T14:00:00.4999Z" => Ok);
-    case!("2019-03-26T14:00:00.4999+10:00" => Ok);
-    case!("2019-03-26t14:00Z" => Err("invalid rfc3339 timestamp: expected 'T' but found 't'"));
-    case!("2019-03-26T14:00z" => Err("invalid rfc3339 timestamp: invalid time"));
-    case!("2019-03-26T14:00:00,999Z" => Err("invalid rfc3339 timestamp: expected 'Z', '+' or '-' but found ','"));
-    case!("2019-03-26T10:00-04" => Err("invalid rfc3339 timestamp: invalid time"));
-    case!("2019-03-26T14:00.9Z" => Err("invalid rfc3339 timestamp: invalid time"));
-    case!("20190326T1400Z" => Err("invalid rfc3339 timestamp: invalid date"));
-    case!("2019-02-30" => Err("invalid rfc3339 timestamp: expected 'T' but found end of string"));
-    case!("2019-03-25T24:01Z" => Err("invalid rfc3339 timestamp: invalid time"));
-    case!("2019-03-26T14:00+24:00" => Err("invalid rfc3339 timestamp: invalid time"));
-    case!("2019-03-26Z" => Err("invalid rfc3339 timestamp: expected 'T' but found 'Z'"));
-    case!("2019-03-26+01:00" => Err("invalid rfc3339 timestamp: expected 'T' but found '+'"));
-    case!("2019-03-26-04:00" => Err("invalid rfc3339 timestamp: expected 'T' but found '-'"));
-    case!("2019-03-26T10:00-0400" => Err("invalid rfc3339 timestamp: invalid time"));
-    case!("+0002019-03-26T14:00Z" => Err("invalid rfc3339 timestamp: invalid date"));
-    case!("+2019-03-26T14:00Z" => Err("invalid rfc3339 timestamp: invalid date"));
-    case!("002019-03-26T14:00Z" => Err("invalid rfc3339 timestamp: invalid date"));
-    case!("019-03-26T14:00Z" => Err("invalid rfc3339 timestamp: invalid date"));
-    case!("2019-03-26T10:00Q" => Err("invalid rfc3339 timestamp: invalid time"));
-    case!("2019-03-26T10:00T" => Err("invalid rfc3339 timestamp: invalid time"));
-    case!("2019-03-26Q" => Err("invalid rfc3339 timestamp: expected 'T' but found 'Q'"));
-    case!("2019-03-26T" => Err("invalid rfc3339 timestamp: invalid time"));
-    case!("2019-03-26 14:00Z" => Err("invalid rfc3339 timestamp: expected 'T' but found ' '"));
-    case!("2019-03-26T14:00:00." => Err("invalid rfc3339 timestamp: empty fractional seconds"));
+    #[test]
+    fn test_get_message_name_type_url() {
+        macro_rules! case {
+            ($s:expr => Ok($e:expr)) => {
+                assert_eq!(get_message_name($s).unwrap(), $e)
+            };
+            ($s:expr => Err($e:expr)) => {
+                assert_eq!(get_message_name($s).unwrap_err(), $e)
+            };
+        }
+
+        case!("type.googleapis.com/my.messages.Message" => Ok("my.messages.Message"));
+        case!("type.googleprod.com/my.messages.Message" => Ok("my.messages.Message"));
+        case!("/my.messages.Message" => Ok("my.messages.Message"));
+        case!("any.url.com/my.messages.Message" => Ok("my.messages.Message"));
+        case!("http://even.multiple/slashes/my.messages.Message" => Ok("my.messages.Message"));
+        case!("/any.type.isAlsoValid" => Ok("any.type.isAlsoValid"));
+        case!("my.messages.Message" => Err("unsupported type url 'my.messages.Message': missing at least one '/'"));
+    }
 }


### PR DESCRIPTION
This PR changes how type url is parsed. Now it completely ignores anything before last '/' as specified by `Any` docs and to be more in-line with default `prost` behaviour.


Closes https://github.com/andrewhickman/prost-reflect/issues/144