### PR TITLE
Include the license files in the crates

### DIFF
--- a/prost-reflect-build/LICENSE-APACHE
+++ b/prost-reflect-build/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/prost-reflect-build/LICENSE-MIT
+++ b/prost-reflect-build/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/prost-reflect-conformance-tests/LICENSE-APACHE
+++ b/prost-reflect-conformance-tests/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/prost-reflect-conformance-tests/LICENSE-MIT
+++ b/prost-reflect-conformance-tests/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/prost-reflect-derive/LICENSE-APACHE
+++ b/prost-reflect-derive/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/prost-reflect-derive/LICENSE-MIT
+++ b/prost-reflect-derive/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/prost-reflect-tests/LICENSE-APACHE
+++ b/prost-reflect-tests/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/prost-reflect-tests/LICENSE-MIT
+++ b/prost-reflect-tests/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/prost-reflect/LICENSE-APACHE
+++ b/prost-reflect/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/prost-reflect/LICENSE-MIT
+++ b/prost-reflect/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
I see that you already did this for `protox` [^1], so you are probably familiar with the need to have this for downstream packagers.

[^1]: https://github.com/andrewhickman/protox/commit/d64e112011fa016c9777da8cd0b426ba0537ad6d