### PR TITLE
Remove binary files from the released crates.io version

### DIFF
--- a/prost-reflect/Cargo.toml
+++ b/prost-reflect/Cargo.toml
@@ -13,6 +13,11 @@ edition = "2021"
 rust-version = "1.74.0"
 exclude = [
     "proptest-regressions",
+    # don't include binary file descriptors into the published packages
+    "**/*.bin",
+    "**/*.proto",
+    # no need to include the test data including snapshots
+    "tests",
 ]
 
 [[test]]


### PR DESCRIPTION
This commit removes the `file_descriptor_set.bin` file that is used by the doc tests from the published crate. It's not used outside of the doc test and including a binary file makes it harder to review the code. Given that users usually not run doc tests for dependencies this should be fine.

Also this PR restricts a bit more which files are explicitly excluded from the published package to prevent the inclusion of such files in the future by:

* Disallowing any `.bin` and `.proto` files
* Removing the test directory (again, includes snapshots, almost all users won't run tests for dependencies)

Overall this reduces the size of the published package from 246 files, 922.6KiB (113.0KiB compressed) to 42 files, 836.7KiB (100.3KiB compressed) which results to a 32GB/month traffic reduction on crates.io based on recent download numbers.