### PR TITLE
feat(descriptor): add is_required method to FieldDescriptor

### DIFF
--- a/prost-reflect/src/descriptor/api.rs
+++ b/prost-reflect/src/descriptor/api.rs
@@ -1075,6 +1075,13 @@ impl FieldDescriptor {
         self.inner().is_packed
     }
 
+    /// Whether this field is required.
+    ///
+    /// For proto3 this always returns `false`.
+    pub fn is_required(&self) -> bool {
+        self.cardinality() == Cardinality::Required
+    }
+
     /// The cardinality of this field.
     pub fn cardinality(&self) -> Cardinality {
         self.inner().cardinality


### PR DESCRIPTION
Add helper method to check if a field is required, which always returns false for proto3