### PR TITLE
fix: restore proto3 default for is_packed when FieldOptions is present but packed is absent

### DIFF
--- a/prost-reflect/src/descriptor/build/resolve.rs
+++ b/prost-reflect/src/descriptor/build/resolve.rs
@@ -123,7 +123,9 @@ impl Visitor for ResolveVisitor<'_> {
             && (field
                 .options
                 .as_ref()
-                .map_or(syntax == Syntax::Proto3, |o| o.value.packed()));
+                .map_or(syntax == Syntax::Proto3, |o| {
+                    o.value.packed.unwrap_or(syntax == Syntax::Proto3)
+                }));
 
         let supports_presence = field.proto3_optional()
             || field.oneof_index.is_some()
@@ -394,7 +396,9 @@ impl Visitor for ResolveVisitor<'_> {
             && (extension
                 .options
                 .as_ref()
-                .map_or(syntax == Syntax::Proto3, |o| o.value.packed()));
+                .map_or(syntax == Syntax::Proto3, |o| {
+                    o.value.packed.unwrap_or(syntax == Syntax::Proto3)
+                }));
 
         let default = kind.and_then(|kind| {
             self.parse_field_default_value(kind, extension.default_value.as_deref(), file, path)

--- a/prost-reflect/tests/main.rs
+++ b/prost-reflect/tests/main.rs
@@ -210,3 +210,54 @@ check_err!(dependency_not_imported);
 check_ok!(dependency_resolution_transitive);
 check_ok!(dependency_resolution_transitive2);
 check_err!(dependency_resolution_transitive3);
+
+// Regression test for https://github.com/andrewhickman/prost-reflect/issues/195
+//
+// is_packed() must return true for a proto3 repeated packable field when
+// FieldOptions is present but carries no explicit `packed` entry (e.g. because
+// a custom option annotation is present).  Previously the map_or closure called
+// packed() which returns unwrap_or(false), silently discarding the proto3
+// default of true.
+#[test]
+fn is_packed_proto3_default_with_present_but_empty_field_options() {
+    use prost::Message as _;
+    use prost_types::{
+        field_descriptor_proto::{Label, Type},
+        DescriptorProto, FieldDescriptorProto, FieldOptions, FileDescriptorProto,
+        FileDescriptorSet,
+    };
+
+    let fds = FileDescriptorSet {
+        file: vec![FileDescriptorProto {
+            name: Some("test.proto".into()),
+            syntax: Some("proto3".into()),
+            message_type: vec![DescriptorProto {
+                name: Some("Foo".into()),
+                field: vec![FieldDescriptorProto {
+                    name: Some("values".into()),
+                    number: Some(1),
+                    label: Some(Label::Repeated as i32),
+                    r#type: Some(Type::Int32 as i32),
+                    // options is Some but has no `packed` field set — as emitted
+                    // by protoc when a custom option is present but packed is unset.
+                    options: Some(FieldOptions::default()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    };
+
+    let pool = DescriptorPool::decode(fds.encode_to_vec().as_slice()).unwrap();
+    let field = pool
+        .get_message_by_name("Foo")
+        .unwrap()
+        .get_field_by_name("values")
+        .unwrap();
+
+    assert!(
+        field.is_packed(),
+        "proto3 repeated int32 with present-but-empty FieldOptions must be packed"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #195.

When a proto3 repeated packable field has `FieldOptions` present in the `FileDescriptorSet` (e.g. due to a custom option annotation) but no explicit `packed` entry, `is_packed()` incorrectly returns `false`.

### Root cause

In `src/descriptor/build/resolve.rs`, at two identical sites (regular fields and extension fields), the `is_packed` computation reads:

```rust
.map_or(syntax == Syntax::Proto3, |o| o.value.packed())
```

`FieldOptions.packed` is `Option<bool>` in `prost-types`. The generated `packed()` accessor returns `self.packed.unwrap_or(false)`. When `options` is `Some` but `packed` is absent, this returns `false` — silently discarding the proto3 default of `true`.

### Fix

Replace both instances with:

```rust
.map_or(syntax == Syntax::Proto3, |o| o.value.packed.unwrap_or(syntax == Syntax::Proto3))
```

This correctly falls back to the syntax-based default when `packed` is absent.

## Changes

- `prost-reflect/src/descriptor/build/resolve.rs`: two-line fix at both `resolve_field` and `resolve_extension` sites
- `prost-reflect/tests/main.rs`: regression test — builds a proto3 `FileDescriptorSet` in memory with a repeated `int32` field carrying `FieldOptions::default()` (present but empty), asserts `is_packed() == true`